### PR TITLE
Updated dependencies for newer rails versions

### DIFF
--- a/singleton_rails.gemspec
+++ b/singleton_rails.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails", "~> 4.0.0"
+  s.add_dependency "rails", ">= 4.0.0"
 
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
I updated the dependencies on the .gemspec file so it can match other rails versions. I needed this because my application is rocking Rails 4.2 for now this gem requires Rails 4.0 or 4.1, depending on the version.
